### PR TITLE
Keep the original websites sort order

### DIFF
--- a/DependencyInjection/AeWhiteLabelExtension.php
+++ b/DependencyInjection/AeWhiteLabelExtension.php
@@ -32,7 +32,6 @@ class AeWhiteLabelExtension extends Extension
             $container->setParameter(sprintf('ae_white_label.website.%s.model', $name), $website);
             $websites[$name] = sprintf('ae_white_label.website.%s', $name);
         }
-        ksort($websites);
 
         $default = $config['default_website'];
         if (isset($websites[$default])) {


### PR DESCRIPTION
This way the user can decide which website has higher priority if two or
more websites would match.

e.g. two websites with the same host, one matched byHost and the other
byUserParam, would require that the website matched byUserParam is set
earlier than the other to stand a chance.